### PR TITLE
unit_test/data.h: include missing <stdint.h> for uint16_t (gcc-13 fix)

### DIFF
--- a/unit_test/data.h
+++ b/unit_test/data.h
@@ -30,6 +30,7 @@
 #define UNIT_TEST_DATA_H_
 
 #include <string.h>
+#include <stdint.h>
 
 #pragma pack(push, 1)
     struct Sample


### PR DESCRIPTION
Without the change build fails on gcc-13 as:

    /build/source/unit_test/data.h:37:9: error: 'uint16_t' does not name a type
       37 |         uint16_t i;
          |         ^~~~~~~~
    /build/source/unit_test/data.h:33:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
       32 | #include <string.h>
      +++ |+#include <cstdint>