### PR TITLE
If built with USE_NEON then must have that in CFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,9 @@ endif(BUILD_TOOLS)
 ########################################################################
 
 # use space-separation format for the pc file
+if(HAS_NEON)
+    set(CM256CC_PC_CFLAGS "-DUSE_NEON"  ${CM256CC_PC_CFLAGS})
+endif()
 STRING(REPLACE ";" " " CM256CC_PC_REQUIRES "${CM256CC_PC_REQUIRES}")
 STRING(REPLACE ";" " " CM256CC_PC_CFLAGS "${CM256CC_PC_CFLAGS}")
 STRING(REPLACE ";" " " CM256CC_PC_LIBS "${CM256CC_PC_LIBS}")


### PR DESCRIPTION
If you try and compile an app without USE_NEON on a NEON platform then gf256.h gets very cranky.  This sticks `-DUSE_NEON` in the pkg-config CFLAGS is the library was built with USE_NEON.