### PR TITLE
Do not print stderr messages when there are no actual errors

### DIFF
--- a/gf256.cpp
+++ b/gf256.cpp
@@ -309,7 +309,6 @@ int gf256_ctx::gf256_init_()
     gf256_muladd_mem_init();
 
     initialized = true;
-    fprintf(stderr, "gf256_ctx::gf256_init_: initialized\n");
     return 0;
 }
 


### PR DESCRIPTION
Could seem like a minor thing, but I have a codebase where this keeps show up in random places, breaking progress bars, etc (think python process pool where now every process in the pool has to print one of those), and it would be nice not to have things going to stderr absent some actual errors.